### PR TITLE
Support setting profiles-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 - Add example with column rename macro ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/19))
+- Add `--profiles-dir` as an option for setting the profiles directory
 - Extend tox matrix to test for dbt-spark minor versions ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/29))
 - Extend testing matrix to test for Python minor version 3.10 ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/30))
 
-## [0.1.1] - 2023-02-22
-
-- Expore `--profiles-dir` as option for setting profiles directory instead of using `DBT_PROFILES_DIR` environment variable
 
 ## [0.1.0] - 2022-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 - Add example with column rename macro ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/19))
 
+## [0.1.1] - 2023-02-22
+
+- Expore `--profiles-dir` as option for setting profiles directory instead of using `DBT_PROFILES_DIR` environment variable
+
 ## [0.1.0] - 2022-07-22
 
 - Run test examples from docs ([issue](https://github.com/godatadriven/pytest-dbt-core/issues/14), [PR](https://github.com/godatadriven/pytest-dbt-core/pull/17))

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -7,7 +7,7 @@ Project directory
 ************************
 When you run `pytest` from the root of your project, you do **not** need to set
 the project directory. If you want to run `pytest` from another location, you
-point the `---dbt-project-dir`
+point the `--dbt-project-dir`
 `option <https://docs.pytest.org/en/6.2.x/usage.html#getting-help-on-version-option-names-environment-variables>`_
 to the root of your project.
 
@@ -20,4 +20,4 @@ than the default, you set the `--dbt-target`
 
 Profiles directory
 **********************
-If you want to change dbt's profiles directory, use the `DBT_PROFILES_DIR` environment `variable <https://docs.getdbt.com/dbt-cli/configure-your-profile/#advanced-customizing-a-profile-directory>`_.
+If you want to change dbt's profiles directory, use the `--profiles-dir` `option <https://docs.getdbt.com/dbt-cli/configure-your-profile/#advanced-customizing-a-profile-directory>`_.

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ addopts = --cov=src
           --ignore=scripts/
           --dbt-project-dir=./tests/dbt_project
           --dbt-target=test
+          --profiles-dir=./tests/dbt_project
 spark_options =
     spark.app.name: dbt-core
     spark.executor.instances: 1
@@ -81,7 +82,6 @@ setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     {py27,pypy}: PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
-    DBT_PROFILES_DIR = {env:DBT_PROFILES_DIR:{toxinidir}/tests/dbt_project}
 passenv =
     PYTEST_*
     PIP_CACHE_DIR
@@ -95,7 +95,6 @@ description = run the tests in docs
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
     {py27,pypy}: PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
-    DBT_PROFILES_DIR = {env:DBT_PROFILES_DIR:{toxinidir}/docs/source/_static/dbt_project}
 passenv =
     PYTEST_*
     PIP_CACHE_DIR

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     {py27,pypy}: PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
+    DBT_PROFILES_DIR = {env:DBT_PROFILES_DIR:{toxinidir}/tests/dbt_project}
 passenv =
     PYTEST_*
     PIP_CACHE_DIR
@@ -108,4 +109,4 @@ deps =
     pip >= 19.3.1
 extras = test
 commands_pre = dbt deps --project-dir {toxinidir}/docs/source/_static/dbt_project
-commands = pytest {posargs:docs/source/_static/dbt_project/tests} --dbt-project-dir={toxinidir}/docs/source/_static/dbt_project
+commands = pytest {posargs:docs/source/_static/dbt_project/tests} --dbt-project-dir={toxinidir}/docs/source/_static/dbt_project --profiles-dir={toxinidir}/docs/source/_static/dbt_project

--- a/src/pytest_dbt_core/fixtures.py
+++ b/src/pytest_dbt_core/fixtures.py
@@ -63,7 +63,7 @@ def config(request: SubRequest) -> RuntimeConfig:
 
     profiles_dir = request.config.getoption("--profiles-dir")
     if profiles_dir:
-        flags.PROFILES_DIR = profiles_dir
+        flags.PROFILES_DIR = os.path.abspath(profiles_dir)
 
     args = Args(
         project_dir=request.config.getoption("--dbt-project-dir"),

--- a/src/pytest_dbt_core/fixtures.py
+++ b/src/pytest_dbt_core/fixtures.py
@@ -60,7 +60,6 @@ def config(request: SubRequest) -> RuntimeConfig:
         The runtime config.
     """
 
-    # only override profiles_dir if its set, otherwise keep DBT behavior
     profiles_dir = request.config.getoption("--profiles-dir")
     if profiles_dir:
         flags.PROFILES_DIR = profiles_dir

--- a/src/pytest_dbt_core/fixtures.py
+++ b/src/pytest_dbt_core/fixtures.py
@@ -8,6 +8,7 @@ import os
 import dbt.tracking
 import pytest
 from _pytest.fixtures import SubRequest
+from dbt import flags
 from dbt.clients.jinja import MacroGenerator
 from dbt.config.runtime import RuntimeConfig
 from dbt.context import providers
@@ -58,6 +59,12 @@ def config(request: SubRequest) -> RuntimeConfig:
     RuntimeConfig
         The runtime config.
     """
+
+    # only override profiles_dir if its set, otherwise keep DBT behavior
+    profiles_dir = request.config.getoption("--profiles-dir")
+    if profiles_dir:
+        flags.PROFILES_DIR = profiles_dir
+
     args = Args(
         project_dir=request.config.getoption("--dbt-project-dir"),
         target=request.config.getoption("--dbt-target"),

--- a/src/pytest_dbt_core/fixtures.py
+++ b/src/pytest_dbt_core/fixtures.py
@@ -42,6 +42,7 @@ class Args:
 
     project_dir: str
     target: str | None
+    profile: str | None
 
 
 @pytest.fixture
@@ -67,6 +68,7 @@ def config(request: SubRequest) -> RuntimeConfig:
     args = Args(
         project_dir=request.config.getoption("--dbt-project-dir"),
         target=request.config.getoption("--dbt-target"),
+        profile=None,
     )
     config = RuntimeConfig.from_args(args)
     return config

--- a/src/pytest_dbt_core/plugin.py
+++ b/src/pytest_dbt_core/plugin.py
@@ -34,3 +34,8 @@ def pytest_addoption(parser: Parser) -> None:
         help="Which target to load for the given profile",
         type="string",
     )
+    parser.addoption(
+        "--profiles-dir",
+        help="Which directory to look in for the profiles.yml file",
+        type="string",
+    )


### PR DESCRIPTION
### Description

Allows user to set `--profiles-dir` instead of needing to set the ENV `DBT_PROFILES_DIR` - setting this option is more flexible than the ENV because it can be done at the command line or as an INI option.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I read the [CONTRIBUTING](https://github.com/godatadriven/pytest-dbt-core/blob/main/CONTRIBUTING.md) guide and understand what's expected of me
- [x] I ran this code in development and it appears to resolve the stated issue
- [ ] I added tests, or tests are not required/relevant for this PR
- [x] I added an entry to the [CHANGELOG](https://github.com/godatadriven/pytest-dbt-core/blob/main/CHANGELOG.md) detailing the change of this PR
