### PR TITLE
Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     name: Run flake8 linter
     additional_dependencies: ["flake8-bugbear==20.11.1", "pep8-naming==0.11.1"]
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.10.1
+  rev: 5.11.5
   hooks:
   - id: isort
     additional_dependencies: [toml]


### PR DESCRIPTION
### Description

Fix pre-commit:

- Bump isort pre-commit version to 5.11.5. Poetry shims broke, see [release notes](https://github.com/PyCQA/isort/releases/tag/5.11.5).

### Checklist

- [x] I read the [CONTRIBUTING](https://github.com/godatadriven/pytest-dbt-core/blob/main/CONTRIBUTING.md) guide and understand what's expected of me
- [x] I ran this code in development and it appears to resolve the stated issue
- [x] I added tests, or tests are not required/relevant for this PR
- [x] I added an entry to the [CHANGELOG](https://github.com/godatadriven/pytest-dbt-core/blob/main/CHANGELOG.md) detailing the change of this PR
