### PR TITLE
Revert "Update dbt-core requirement from <1.5.0,>=1.0.0 to >=1.0.0,<1.6.0"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 packages = find:
 package_dir = =src
 install_requires =
-    dbt-core>=1.0.0,<1.6.0
+    dbt-core>=1.0.0,<1.5.0
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
Reverts godatadriven/pytest-dbt-core#32