### PR TITLE
Remove dbt upper version constrain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Remove upper version constrain for dbt core ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/43))
+
 ## [0.2.2] - 2023-08-09
 
 - Support dbt v1.6 ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/37), [PR](https://github.com/godatadriven/pytest-dbt-core/pull/38))

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 packages = find:
 package_dir = =src
 install_requires =
-    dbt-core>=1.0.0,<1.7.0
+    dbt-core>=1.0.0
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
### Description

Remove dbt upper version constrain. We need to update the testing, but users should be able to install newer version right away.

### Checklist

- [x] I read the [CONTRIBUTING](https://github.com/godatadriven/pytest-dbt-core/blob/main/CONTRIBUTING.md) guide and understand what's expected of me
- [x] I ran this code in development and it appears to resolve the stated issue
- [x] I added tests, or tests are not required/relevant for this PR
- [x] I added an entry to the [CHANGELOG](https://github.com/godatadriven/pytest-dbt-core/blob/main/CHANGELOG.md) detailing the change of this PR
