### PR TITLE
Release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.2.3] - 2023-08-25
+
 - Remove upper version constrain for dbt core ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/43))
 - CI speed up: ignore redundant tox environments ([issue](https://github.com/godatadriven/pytest-dbt-core/issues/44), [PR](https://github.com/godatadriven/pytest-dbt-core/pull/45))
 - Test for Python 3.11 ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/41))


### PR DESCRIPTION
- Remove upper version constrain for dbt core ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/43))
- CI speed up: ignore redundant tox environments ([issue](https://github.com/godatadriven/pytest-dbt-core/issues/44), [PR](https://github.com/godatadriven/pytest-dbt-core/pull/45))
- Test for Python 3.11 ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/41))

### Checklist

- [x] I read the [CONTRIBUTING](https://github.com/godatadriven/pytest-dbt-core/blob/main/CONTRIBUTING.md) guide and understand what's expected of me
- [x] I ran this code in development and it appears to resolve the stated issue
- [x] I added tests, or tests are not required/relevant for this PR
- [x] I added an entry to the [CHANGELOG](https://github.com/godatadriven/pytest-dbt-core/blob/main/CHANGELOG.md) detailing the change of this PR
