### PR TITLE
Release 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Test dbt v1.7 ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/48))
 - Make pytest `parser.addoption` type a function ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/51))
-- Handle dbt flags for dbt version 1.6 and higher
+- Handle dbt flags for dbt version 1.6 and higher ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/52))
 
 ## [0.2.3] - 2023-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.2.4] - 2024-06-02
+
 - Test dbt v1.7 ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/48))
 - Make pytest `parser.addoption` type a function ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/51))
 - Handle dbt flags for dbt version 1.6 and higher


### PR DESCRIPTION
- Test dbt v1.7 ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/48))
- Make pytest `parser.addoption` type a function ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/51))
- Handle dbt flags for dbt version 1.6 and higher ([PR](https://github.com/godatadriven/pytest-dbt-core/pull/52))
